### PR TITLE
Refactor Tk app to use win32mica for theming

### DIFF
--- a/topstats/app.py
+++ b/topstats/app.py
@@ -17,7 +17,6 @@ from .downloaders import (
     fetch_latest_gw2_ei_log_combiner_version,
     check_for_app_update,
 )
-from .window_utils import set_native_title_bar_theme
 
 config = load_config()
 
@@ -148,18 +147,6 @@ if os.name != 'nt':
 # App window
 root = tk.Tk()
 root.title("GW2 arcdps File Selector")
-root.configure(bg="#313131")  # Default dark theme background
-
-# Load the Forest theme from the "themes" directory
-themes_dir = os.path.join(os.getcwd(), "themes")
-forest_dark_path = os.path.join(themes_dir, "forest-dark.tcl")
-forest_light_path = os.path.join(themes_dir, "forest-light.tcl")
-
-# Check if the theme files exist
-if (os.path.exists(forest_dark_path)):
-    root.tk.call("source", forest_dark_path)
-if (os.path.exists(forest_light_path)):
-    root.tk.call("source", forest_light_path)
 
 apply_theme(root, config)
 
@@ -497,7 +484,5 @@ release_label = ttk.Label(root, text=f"Release: {release_version}", font=("Arial
 release_label.grid(row=4, column=0, sticky="e", padx=10, pady=5)
 
 threading.Thread(target=lambda: check_for_app_update(root, config), daemon=True).start()
-
-set_native_title_bar_theme(root, config.get("theme", "dark"))
 
 root.mainloop()

--- a/topstats/config.py
+++ b/topstats/config.py
@@ -1,7 +1,9 @@
 import os
 import json
 from datetime import datetime
-from tkinter import messagebox, ttk
+from tkinter import messagebox
+
+from .window_utils import set_native_title_bar_theme
 
 CONFIG_FILE = "config.json"
 
@@ -44,63 +46,9 @@ def get_default_time(config):
 def apply_theme(root, config):
     """Apply the selected theme to the given root window."""
     selected_theme = config.get("theme", "dark")
-    if selected_theme == "dark":
-        ttk.Style().theme_use("forest-dark")
-        bg = "#313131"
-        dark_mode = True
-    else:
-        ttk.Style().theme_use("forest-light")
-        bg = "#ffffff"
-        dark_mode = False
-
+    bg = "#333333" if selected_theme == "dark" else "#FFFFFF"
     root.configure(bg=bg)
-
-    # Delay applying the title bar color until the window is initialized
-    root.after(0, lambda: _set_title_bar_color(root, bg, dark_mode=dark_mode))
-
-
-def _set_title_bar_color(root, color, dark_mode=False):
-    """Set the native title bar color on Windows."""
-    if os.name != "nt":
-        return
-
-    try:
-        from ctypes import byref, c_int, c_uint, sizeof, windll
-
-        root.update_idletasks()
-        hwnd = root.winfo_id()
-
-        DWMWA_USE_IMMERSIVE_DARK_MODE = 20
-        DWMWA_CAPTION_COLOR = 35
-        DWMWA_BORDER_COLOR = 34
-
-        use_dark = c_int(1 if dark_mode else 0)
-        try:
-            windll.dwmapi.DwmSetWindowAttribute(
-                hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, byref(use_dark), sizeof(use_dark)
-            )
-        except Exception:
-            # Windows 10 uses a different attribute value
-            windll.dwmapi.DwmSetWindowAttribute(
-                hwnd, 19, byref(use_dark), sizeof(use_dark)
-            )
-
-        color_value = int(color.lstrip("#"), 16)
-        bgr = c_uint(
-            (color_value & 0xFF) << 16
-            | (color_value & 0xFF00)
-            | (color_value >> 16)
-        )
-
-        # Set caption and border colors to match the theme
-        windll.dwmapi.DwmSetWindowAttribute(
-            hwnd, DWMWA_CAPTION_COLOR, byref(bgr), sizeof(bgr)
-        )
-        windll.dwmapi.DwmSetWindowAttribute(
-            hwnd, DWMWA_BORDER_COLOR, byref(bgr), sizeof(bgr)
-        )
-    except Exception:
-        pass
+    root.after(0, lambda: set_native_title_bar_theme(root, selected_theme))
 
 
 def validate_config(config):

--- a/topstats/config_ui.py
+++ b/topstats/config_ui.py
@@ -75,12 +75,7 @@ def open_config_window(root, config, date_entry, update_status=None, config_butt
             print(f"Could not load icon for config window: {e}")
 
     selected_theme = config.get("theme", "dark")
-    if selected_theme == "dark":
-        config_window_instance.configure(bg="#333333")
-    else:
-        config_window_instance.configure(bg="#FFFFFF")
-
-    set_native_title_bar_theme(config_window_instance, selected_theme)  # <-- Add this line
+    set_native_title_bar_theme(config_window_instance, selected_theme)
 
     config_window_instance.grid_rowconfigure(0, weight=1)
     config_window_instance.grid_columnconfigure(0, weight=1)

--- a/topstats/window_utils.py
+++ b/topstats/window_utils.py
@@ -1,12 +1,42 @@
-import ctypes as ct
+import os
 
-def set_native_title_bar_theme(window, theme="dark"):
+if os.name == "nt":
+    try:
+        from win32mica import ApplyMica, MicaTheme
+    except Exception:  # pragma: no cover - win32mica may not be available
+        ApplyMica = None
+        MicaTheme = None
+else:  # Non-Windows platforms do not support win32mica
+    ApplyMica = None
+    MicaTheme = None
+
+
+def set_native_title_bar_theme(window, theme: str = "dark") -> None:
+    """Apply the requested title bar theme using win32mica.
+
+    Parameters
+    ----------
+    window:
+        The Tk or Toplevel window to theme.
+    theme:
+        Either "dark" or "light".
+    """
+
+    if ApplyMica is None:
+        return  # win32mica not available or not on Windows
+
     window.update_idletasks()
-    DWMWA_USE_IMMERSIVE_DARK_MODE = 20
-    set_window_attribute = ct.windll.dwmapi.DwmSetWindowAttribute
-    get_parent = ct.windll.user32.GetParent
 
-    hwnd = get_parent(window.winfo_id())
-    value = 2 if theme == "dark" else 0  # 2 = dark, 0 = light
-    value = ct.c_int(value)
-    set_window_attribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ct.byref(value), ct.sizeof(value))
+    bg = "#333333" if theme == "dark" else "#FFFFFF"
+    try:
+        window.configure(bg=bg)
+    except Exception:
+        pass
+
+    try:
+        hwnd = window.winfo_id()
+        mica_theme = MicaTheme.DARK if theme == "dark" else MicaTheme.LIGHT
+        ApplyMica(HWND=hwnd, Theme=mica_theme)
+    except Exception:
+        pass
+


### PR DESCRIPTION
## Summary
- replace custom ttk theme handling with win32mica-based theming
- simplify configuration windows to use new theming utility
- remove legacy theme sourcing from main application

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689adb2047d0832fb202c8d00a3e7e04