### PR TITLE
Add skeleton loading screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,9 +151,37 @@
       .parse-step.error .step-status { color:#e81123; }
 
       input:focus, button:focus { outline:none; box-shadow:0 0 0 1px var(--btn-border); border-color:var(--btn-border); }
+      /* Skeleton screen styles */
+      #skeleton-screen { position:fixed; inset:0; background:#f0f0f0; z-index:10000; display:flex; flex-direction:column; gap:16px; padding:16px; transition:opacity 0.3s ease; }
+      #skeleton-screen.hidden { opacity:0; pointer-events:none; }
+      .skeleton { background:linear-gradient(90deg,#e0e0e0 25%,#f5f5f5 37%,#e0e0e0 63%); background-size:400% 100%; animation:shimmer 1.4s ease infinite; }
+      .skeleton-row { display:flex; align-items:center; gap:12px; }
+      .skeleton-avatar { width:40px; height:40px; border-radius:50%; }
+      .skeleton-line { height:12px; border-radius:4px; margin-bottom:8px; }
+      .skeleton-line.short { width:60%; }
+      .skeleton-block { height:120px; border-radius:8px; }
+      @keyframes shimmer { 0% { background-position:-400px 0; } 100% { background-position:400px 0; } }
     </style>
 </head>
 <body>
+  <div id="skeleton-screen">
+    <div class="skeleton-row">
+      <div class="skeleton-avatar skeleton"></div>
+      <div style="flex:1;">
+        <div class="skeleton-line skeleton"></div>
+        <div class="skeleton-line skeleton short"></div>
+      </div>
+    </div>
+    <div class="skeleton-block skeleton"></div>
+    <div class="skeleton-row">
+      <div class="skeleton-avatar skeleton"></div>
+      <div style="flex:1;">
+        <div class="skeleton-line skeleton"></div>
+        <div class="skeleton-line skeleton short"></div>
+      </div>
+    </div>
+    <div class="skeleton-block skeleton"></div>
+  </div>
   <div id="titlebar">
     <div id="title-left">
       <img src="media/TopStatsAIO-Logo.png" id="title-logo" alt="Top Stats AIO Logo" />

--- a/renderer.js
+++ b/renderer.js
@@ -174,6 +174,11 @@ window.electronAPI.onTreeEnd(parent => {
   if (parent === currentFolder) {
     progressContainer.classList.add('hidden');
     fileTreeContainer.classList.remove('hidden');
+    const skeleton = document.getElementById('skeleton-screen');
+    if (skeleton) {
+      skeleton.classList.add('hidden');
+      setTimeout(() => skeleton.remove(), 300);
+    }
   }
 });
 window.electronAPI.onLoadProgress(data => {
@@ -221,6 +226,12 @@ window.electronAPI.onLoadProgress(data => {
   }
   if (saved) {
     setTimeout(() => startLoad(saved, true), 0);
+  } else {
+    const skeleton = document.getElementById('skeleton-screen');
+    if (skeleton) {
+      skeleton.classList.add('hidden');
+      setTimeout(() => skeleton.remove(), 300);
+    }
   }
   // Defer dependency checks until the browser is idle so startup renders faster
   const deferDeps = () => {


### PR DESCRIPTION
## Summary
- Add animated skeleton placeholders that display while the app initializes
- Hide skeleton screen once folder data loads or immediately when no folder is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2000a52e4832fb6099ef7f860d746