### PR TITLE
Fix dependency version text not updating after first install

### DIFF
--- a/main.js
+++ b/main.js
@@ -114,19 +114,39 @@ async function downloadDependency(which) {
 async function checkDependencies() {
   ensureDeps();
   const versions = readVersions();
-  const [cliRel, combRel, parserRel] = await Promise.all([
-    getLatest('baaron4/GW2-Elite-Insights-Parser'),
-    getLatest('Drevarr/GW2_EI_log_combiner'),
-    getLatest('Drevarr/arcdps_top_stats_parser')
-  ]);
-  const cliVer = cliRel.tag_name || cliRel.name;
-  const combVer = combRel.tag_name || combRel.name;
-  const parserVer = parserRel.tag_name || parserRel.name;
-  return {
-    cli: { current: versions.cli, latest: cliVer, needsUpdate: versions.cli !== cliVer },
-    combiner: { current: versions.combiner, latest: combVer, needsUpdate: versions.combiner !== combVer },
-    parser: { current: versions.parser, latest: parserVer, needsUpdate: versions.parser !== parserVer }
+  const result = {
+    cli: { current: versions.cli || null, latest: null, needsUpdate: false },
+    combiner: { current: versions.combiner || null, latest: null, needsUpdate: false },
+    parser: { current: versions.parser || null, latest: null, needsUpdate: false }
   };
+
+  try {
+    const rel = await getLatest('baaron4/GW2-Elite-Insights-Parser');
+    result.cli.latest = rel.tag_name || rel.name;
+    result.cli.needsUpdate = result.cli.current !== result.cli.latest;
+  } catch (e) {
+    console.error('Failed to fetch CLI release', e);
+  }
+
+  try {
+    const rel = await getLatest('Drevarr/GW2_EI_log_combiner');
+    result.combiner.latest = rel.tag_name || rel.name;
+    result.combiner.needsUpdate = result.combiner.current !== result.combiner.latest;
+  } catch (e) {
+    console.error('Failed to fetch combiner release', e);
+  }
+
+  if (versions.parser) {
+    try {
+      const rel = await getLatest('Drevarr/arcdps_top_stats_parser');
+      result.parser.latest = rel.tag_name || rel.name;
+      result.parser.needsUpdate = result.parser.current !== result.parser.latest;
+    } catch (e) {
+      console.error('Failed to fetch parser release', e);
+    }
+  }
+
+  return result;
 }
 
 function createWindow() {

--- a/renderer.js
+++ b/renderer.js
@@ -161,23 +161,24 @@ async function checkDeps() {
   const token = ++checkDepsToken;
   const info = await window.electronAPI.checkDependencies();
   if (token !== checkDepsToken) return;
-  const needCli = info.cli.needsUpdate;
-  const needComb = info.combiner.needsUpdate;
-  const needParser = info.parser.needsUpdate;
+  const needCli = info.cli?.needsUpdate;
+  const needComb = info.combiner?.needsUpdate;
+  const installedParser = !!info.parser?.current;
+  const needParser = installedParser && info.parser.needsUpdate;
   downloadCliBtn.classList.toggle('notify', needCli);
   downloadCombinerBtn.classList.toggle('notify', needComb);
   downloadParserBtn.classList.toggle('notify', needParser);
   settingsBtn.classList.toggle('notify', needCli || needComb || needParser);
-  cliVersionText.textContent = info.cli.current ? `Current: ${info.cli.current}` : 'Not installed';
-  if (needCli) {
+  cliVersionText.textContent = info.cli?.current ? `Current: ${info.cli.current}` : 'Not installed';
+  if (needCli && info.cli?.latest) {
     cliVersionText.textContent += ` (Latest: ${info.cli.latest})`;
   }
-  combinerVersionText.textContent = info.combiner.current ? `Current: ${info.combiner.current}` : 'Not installed';
-  if (needComb) {
+  combinerVersionText.textContent = info.combiner?.current ? `Current: ${info.combiner.current}` : 'Not installed';
+  if (needComb && info.combiner?.latest) {
     combinerVersionText.textContent += ` (Latest: ${info.combiner.latest})`;
   }
-  parserVersionText.textContent = info.parser.current ? `Current: ${info.parser.current}` : 'Not installed';
-  if (needParser) {
+  parserVersionText.textContent = info.parser?.current ? `Current: ${info.parser.current}` : 'Not installed';
+  if (needParser && info.parser?.latest) {
     parserVersionText.textContent += ` (Latest: ${info.parser.latest})`;
   }
 }

--- a/renderer.js
+++ b/renderer.js
@@ -46,6 +46,7 @@ let rootList;
 let folderLists = new Map();
 let loadAll = false;
 let currentStepId = null;
+let checkDepsToken = 0;
 
 dpsUserTokenInput.value = localStorage.getItem('dpsReportUserToken') || '';
 combinerGuildNameInput.value = localStorage.getItem('combinerGuildName') || '';
@@ -94,19 +95,19 @@ downloadCliBtn.addEventListener('click', async () => {
   downloadCliBtn.disabled = true;
   await window.electronAPI.downloadDependency('cli');
   downloadCliBtn.disabled = false;
-  checkDeps();
+  await checkDeps();
 });
 downloadCombinerBtn.addEventListener('click', async () => {
   downloadCombinerBtn.disabled = true;
   await window.electronAPI.downloadDependency('combiner');
   downloadCombinerBtn.disabled = false;
-  checkDeps();
+  await checkDeps();
 });
 downloadParserBtn.addEventListener('click', async () => {
   downloadParserBtn.disabled = true;
   await window.electronAPI.downloadDependency('parser');
   downloadParserBtn.disabled = false;
-  checkDeps();
+  await checkDeps();
 });
 parserTopStatsRadio.addEventListener('change', () => {
   if (parserTopStatsRadio.checked) {
@@ -157,7 +158,9 @@ window.electronAPI.onParseComplete(success => {
   updateStep({ id: 'complete', title: success ? 'Completed' : 'Failed', progress: 1, error: success ? null : 'Error', success });
 });
 async function checkDeps() {
+  const token = ++checkDepsToken;
   const info = await window.electronAPI.checkDependencies();
+  if (token !== checkDepsToken) return;
   const needCli = info.cli.needsUpdate;
   const needComb = info.combiner.needsUpdate;
   const needParser = info.parser.needsUpdate;


### PR DESCRIPTION
## Summary
- ensure outdated dependency checks don't overwrite new results
- await dependency version checks after each download

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a232b5b58c832fb80b9969253ef814