### PR TITLE
feat: add parser folder shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,9 @@
           <div class="dep-row">
             <label><input type="radio" name="parser" id="parser-combiner" value="combiner" /> GW2 EI Log Combiner</label>
           </div>
+          <div class="dep-row">
+            <button id="open-parser-folder">Open Parser Folder</button>
+          </div>
         </div>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -321,6 +321,25 @@ ipcMain.handle('open-parsed-folder', async () => {
   }
 });
 
+ipcMain.handle('open-parser-folder', async (event, which) => {
+  ensureDeps();
+  const dir = path.join(depsDir, which === 'topstats' ? 'topstatsparser' : 'logcombiner');
+  try {
+    await shell.openPath(dir);
+    const ex1 = path.join(dir, 'example_output');
+    const ex2 = path.join(dir, 'Example_Output');
+    if (fs.existsSync(ex1)) {
+      await shell.openPath(ex1);
+    } else if (fs.existsSync(ex2)) {
+      await shell.openPath(ex2);
+    }
+    return true;
+  } catch (e) {
+    logError('Failed to open parser folder', e);
+    return false;
+  }
+});
+
 ipcMain.handle('open-external', async (event, url) => {
   await shell.openExternal(url);
 });

--- a/preload.js
+++ b/preload.js
@@ -22,6 +22,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onParseComplete: (cb) => ipcRenderer.on('parse-complete', (e, success) => cb(success)),
   openParsedFolder: () => ipcRenderer.invoke('open-parsed-folder'),
   cancelParse: () => ipcRenderer.send('cancel-parse'),
+  openParserFolder: (which) => ipcRenderer.invoke('open-parser-folder', which),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
   showUpdatePrompt: () => ipcRenderer.invoke('show-update-prompt'),
   onShowUpdateNotice: (cb) => ipcRenderer.on('show-update-notice', () => cb()),

--- a/renderer.js
+++ b/renderer.js
@@ -24,6 +24,7 @@ const combinerVersionText = document.getElementById('combiner-version');
 const parserVersionText = document.getElementById('parser-version');
 const parserTopStatsRadio = document.getElementById('parser-topstats');
 const parserCombinerRadio = document.getElementById('parser-combiner');
+const openParserFolderBtn = document.getElementById('open-parser-folder');
 const dpsUserTokenInput = document.getElementById('dps-user-token');
 const combinerGuildNameInput = document.getElementById('combiner-guild-name');
 const combinerGuildIdInput = document.getElementById('combiner-guild-id');
@@ -119,6 +120,10 @@ parserCombinerRadio.addEventListener('change', () => {
     localStorage.setItem('parserSelection', 'combiner');
     updateDescriptionVisibility();
   }
+});
+openParserFolderBtn.addEventListener('click', () => {
+  const sel = localStorage.getItem('parserSelection') || 'combiner';
+  window.electronAPI.openParserFolder(sel);
 });
 dpsUserTokenInput.addEventListener('input', () => {
   localStorage.setItem('dpsReportUserToken', dpsUserTokenInput.value);


### PR DESCRIPTION
## Summary
- add settings button to open parser or combiner directories
- expose IPC to open parser location and example folder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2606813c4832fba15e2daa3a4b9ab