### PR TITLE
Improve parse window output formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,8 @@
 
       #parse-window { position:fixed; top:32px; left:0; right:0; bottom:0; background:transparent; padding:40px; display:flex; flex-direction:column; gap:20px; overflow:auto; opacity:0; pointer-events:none; transition:opacity 0.3s ease; z-index:1; }
       #parse-window.active { opacity:1; pointer-events:auto; }
-      .parse-output { background:var(--bg-btn); color:var(--text-color); border:1px solid transparent; border-radius:8px; padding:10px; flex:1; overflow:auto; border-image:var(--card-border); -webkit-user-select:text; user-select:text; }
+      .parse-output { background:var(--bg-btn); color:var(--text-color); border:1px solid transparent; border-radius:8px; padding:10px; flex:1; overflow:auto; border-image:var(--card-border); -webkit-user-select:text; user-select:text; font-family:monospace; white-space:pre-wrap; display:flex; flex-direction:column; gap:4px; }
+      .parse-line.error { color:#e81123; }
       .parse-actions { display:flex; gap:10px; }
 
       #parse-steps { display:flex; flex-direction:column; gap:10px; }
@@ -243,7 +244,7 @@
   <div id="parse-window">
     <h2 class="parse-header">Parsing Logs</h2>
     <div id="parse-steps"></div>
-    <pre id="parse-output" class="parse-output"></pre>
+    <div id="parse-output" class="parse-output"></div>
     <div class="parse-actions">
       <button id="parse-cancel">Cancel</button>
       <button id="parse-open-folder" disabled>Open Folder</button>

--- a/renderer.js
+++ b/renderer.js
@@ -213,7 +213,13 @@ parseCancelBtn.addEventListener('click', () => {
   window.electronAPI.cancelParse();
 });
 window.electronAPI.onParseProgress(msg => {
-  parseOutput.textContent += msg + '\n';
+  const line = document.createElement('div');
+  line.textContent = msg;
+  line.classList.add('parse-line');
+  if (msg.toLowerCase().includes('error')) {
+    line.classList.add('error');
+  }
+  parseOutput.appendChild(line);
   parseOutput.scrollTop = parseOutput.scrollHeight;
 });
 window.electronAPI.onParseStep(data => updateStep(data));
@@ -718,7 +724,7 @@ function openParseWindow() {
   mainWindowEl.classList.add('fade-out');
   parseWindow.classList.add('active');
   document.getElementById('title-text').textContent = 'Parse';
-  parseOutput.textContent = '';
+  parseOutput.innerHTML = '';
   parseSteps.innerHTML = '';
   currentStepId = null;
   parseOpenFolderBtn.disabled = true;


### PR DESCRIPTION
## Summary
- display parse log lines individually with spacing for readability
- style parse output container for better visibility and error highlighting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38494a930832fafd1e02e546b38b4