### PR TITLE
feat: add acrylic theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,16 @@
         --progress-track:#ccc;
         --btn-border-hover:#8e44ad;
       }
+      body.acrylic {
+        --bg-btn:rgba(30,30,30,0.6);
+        --bg-btn-hover:rgba(45,45,45,0.6);
+        --label-bg:rgba(30,30,30,0.6);
+        --card-bg:rgba(0,0,0,0.2);
+        --scroll-track:rgba(30,30,30,0.6);
+        --scroll-thumb:rgba(255,255,255,0.3);
+        --scroll-thumb-hover:rgba(255,255,255,0.5);
+        backdrop-filter:blur(20px);
+      }
       body { color:var(--text-color); background:transparent; font-family:'Segoe UI', sans-serif; margin:0; padding:20px; overflow:hidden; -webkit-user-select:none; user-select:none; }
       input, textarea { -webkit-user-select:text; user-select:text; }
       #titlebar { height:32px; display:flex; align-items:center; justify-content:space-between; -webkit-app-region:drag; position:fixed; top:0; left:0; right:0; overflow:hidden; padding-left:8px; }
@@ -360,6 +370,7 @@
           <div class="dep-row">
             <button id="theme-dark" class="theme-btn">Dark</button>
             <button id="theme-light" class="theme-btn">Light</button>
+            <button id="theme-acrylic" class="theme-btn">Acrylic</button>
           </div>
           <div class="dep-row">
             <details id="gradient-drawer">

--- a/main.js
+++ b/main.js
@@ -176,7 +176,7 @@ function createWindow() {
     width: 1100,
     height: 800,
     backgroundColor: useMica ? '#00000000' : '#2d2d2d',
-    ...(useMica ? { backgroundMaterial: 'mica', visualEffectState: 'active' } : {}),
+    ...(useMica ? { backgroundMaterial: appTheme === 'acrylic' ? 'acrylic' : 'mica', visualEffectState: 'active' } : {}),
     titleBarStyle: 'hidden',
     title: 'Top Stats AIO',
     icon: path.join(__dirname, 'media', 'TopStatsAIO-Logo.ico'),
@@ -207,7 +207,7 @@ function showUpdatePrompt(parent) {
     resizable: false,
     frame: false,
     backgroundColor: useMica ? '#00000000' : '#2d2d2d',
-    ...(useMica ? { backgroundMaterial: 'mica', visualEffectState: 'active' } : {}),
+    ...(useMica ? { backgroundMaterial: appTheme === 'acrylic' ? 'acrylic' : 'mica', visualEffectState: 'active' } : {}),
     titleBarStyle: 'hidden',
     show: false,
     webPreferences: {
@@ -351,8 +351,9 @@ ipcMain.handle('get-version', () => app.getVersion());
 
 ipcMain.on('set-theme', (event, theme) => {
   appTheme = theme;
-  nativeTheme.themeSource = theme;
+  nativeTheme.themeSource = theme === 'light' ? 'light' : 'dark';
   BrowserWindow.getAllWindows().forEach(w => {
+    if (useMica) w.setBackgroundMaterial(theme === 'acrylic' ? 'acrylic' : 'mica');
     w.webContents.send('theme-changed', theme);
   });
 });

--- a/renderer.js
+++ b/renderer.js
@@ -22,6 +22,7 @@ const settingsWindow = document.getElementById('settings-window');
 const closeSettingsBtn = document.getElementById('close-settings');
 const darkBtn = document.getElementById('theme-dark');
 const lightBtn = document.getElementById('theme-light');
+const acrylicBtn = document.getElementById('theme-acrylic');
 const downloadCliBtn = document.getElementById('download-cli');
 const downloadCombinerBtn = document.getElementById('download-combiner');
 const downloadParserBtn = document.getElementById('download-parser');
@@ -174,6 +175,7 @@ function updateDescriptionVisibility() {
 
 darkBtn.addEventListener('click', () => window.electronAPI.setTheme('dark'));
 lightBtn.addEventListener('click', () => window.electronAPI.setTheme('light'));
+acrylicBtn.addEventListener('click', () => window.electronAPI.setTheme('acrylic'));
 gradientRadios.forEach(radio => {
   radio.addEventListener('change', () => {
     if (radio.checked) {
@@ -414,11 +416,12 @@ window.electronAPI.onLoadProgress(data => {
 
 document.addEventListener('DOMContentLoaded', async () => {
   const savedTheme = localStorage.getItem('theme');
-  let theme = savedTheme === 'light' || savedTheme === 'dark' ? savedTheme : await window.electronAPI.getTheme();
-  if (theme !== 'light' && theme !== 'dark') {
+  let theme = ['light', 'dark', 'acrylic'].includes(savedTheme) ? savedTheme : await window.electronAPI.getTheme();
+  if (!['light', 'dark', 'acrylic'].includes(theme)) {
     theme = 'dark';
   }
   applyTheme(theme);
+  window.electronAPI.setTheme(theme);
   const grad = localStorage.getItem('gradientTheme') || 'default';
   applyGradient(grad);
   const savedRadio = document.querySelector(`input[name="gradient-theme"][value="${grad}"]`);
@@ -970,12 +973,19 @@ async function startParse() {
 
 function applyTheme(theme) {
   document.body.classList.toggle('light', theme === 'light');
+  document.body.classList.toggle('acrylic', theme === 'acrylic');
   if (theme === 'light') {
     lightBtn.classList.add('selected');
     darkBtn.classList.remove('selected');
+    acrylicBtn.classList.remove('selected');
+  } else if (theme === 'acrylic') {
+    acrylicBtn.classList.add('selected');
+    darkBtn.classList.remove('selected');
+    lightBtn.classList.remove('selected');
   } else {
     darkBtn.classList.add('selected');
     lightBtn.classList.remove('selected');
+    acrylicBtn.classList.remove('selected');
   }
   localStorage.setItem('theme', theme);
 }


### PR DESCRIPTION
## Summary
- add acrylic theme option alongside dark and light modes
- support Windows 11 acrylic background in renderer and main windows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0076bea8832fb0313b9586a363f8