### PR TITLE
feat: add guild lookup button

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
           <div class="config-row">
             <label for="combiner-guild-id">Guild ID</label>
             <input type="text" id="combiner-guild-id" class="config-input" />
+            <button id="combiner-guild-lookup" class="small-btn" style="margin-left:auto;">Lookup</button>
           </div>
           <div class="config-row">
             <label for="combiner-api-key">API Key</label>

--- a/renderer.js
+++ b/renderer.js
@@ -37,6 +37,7 @@ const uploadUrlInput = document.getElementById('upload-url');
 const uploadLoginBtn = document.getElementById('upload-login');
 const combinerGuildNameInput = document.getElementById('combiner-guild-name');
 const combinerGuildIdInput = document.getElementById('combiner-guild-id');
+const combinerGuildLookupBtn = document.getElementById('combiner-guild-lookup');
 const combinerApiKeyInput = document.getElementById('combiner-api-key');
 const combinerGlickoCheckbox = document.getElementById('combiner-glicko');
 const combinerFightChartsCheckbox = document.getElementById('combiner-fight-charts');
@@ -102,6 +103,7 @@ dpsUserTokenInput.value = localStorage.getItem('dpsReportUserToken') || '';
 uploadUrlInput.value = localStorage.getItem('uploadUrl') || '';
 combinerGuildNameInput.value = localStorage.getItem('combinerGuildName') || '';
 combinerGuildIdInput.value = localStorage.getItem('combinerGuildId') || '';
+combinerGuildLookupBtn.disabled = !combinerGuildNameInput.value.trim();
 combinerApiKeyInput.value = localStorage.getItem('combinerApiKey') || '';
 combinerGlickoCheckbox.checked = localStorage.getItem('combinerGlickoUpdate') === 'true';
 combinerFightChartsCheckbox.checked = localStorage.getItem('combinerFightCharts') === 'true';
@@ -287,9 +289,34 @@ setupTiddlyhostBtn.addEventListener('click', () => {
 });
 combinerGuildNameInput.addEventListener('input', () => {
   localStorage.setItem('combinerGuildName', combinerGuildNameInput.value);
+  combinerGuildLookupBtn.disabled = !combinerGuildNameInput.value.trim();
 });
 combinerGuildIdInput.addEventListener('input', () => {
   localStorage.setItem('combinerGuildId', combinerGuildIdInput.value);
+});
+combinerGuildLookupBtn.addEventListener('click', async () => {
+  const name = combinerGuildNameInput.value.trim();
+  if (!name) return;
+  try {
+    const res = await fetch(`https://api.guildwars2.com/v2/guild/search?name=${encodeURIComponent(name)}`);
+    if (!res.ok) {
+      if (res.status === 404) {
+        alert('No guild found. Ensure the name is spelled exactly and does not include the guild tag.');
+      } else {
+        alert('Error looking up guild.');
+      }
+      return;
+    }
+    const ids = await res.json();
+    if (!Array.isArray(ids) || ids.length === 0) {
+      alert('No guild found. Ensure the name is spelled exactly and does not include the guild tag.');
+      return;
+    }
+    combinerGuildIdInput.value = ids[0];
+    localStorage.setItem('combinerGuildId', ids[0]);
+  } catch (err) {
+    alert('Error looking up guild.');
+  }
 });
 combinerApiKeyInput.addEventListener('input', () => {
   localStorage.setItem('combinerApiKey', combinerApiKeyInput.value);


### PR DESCRIPTION
## Summary
- add Lookup button next to Guild ID field
- fetch guild ID by guild name and populate field
- handle missing guild names and lookup errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace8b7d7cc832fb28a80fd509b217a