### PR TITLE
Add hide columns toggle for GW2 EI Log Combiner

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -28,10 +28,11 @@ describe('utils', () => {
   test('editEIConfig replaces values', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tsaio-'));
     const dest = path.join(tempDir, 'out.conf');
-    await editEIConfig(path.join(__dirname, '..', 'EliteInsightsConfigTemplate.conf'), dest, 'C:/out', 'token123');
+    await editEIConfig(path.join(__dirname, '..', 'EliteInsightsConfigTemplate.conf'), dest, 'C:/out', 'token123', { anonymizePlayers: true });
     const content = fs.readFileSync(dest, 'utf8');
     expect(content).toMatch('OutLocation=C:/out');
     expect(content).toMatch('DPSReportUserToken=token123');
+    expect(content).toMatch('Anonymous=True');
   });
 
   test('editTopStatsConfig replaces values', async () => {

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -44,6 +44,7 @@ describe('utils', () => {
       dbPath: 'C:/data',
       dbUpdate: true,
       fightCharts: true,
+      hideColumns: true,
     });
     const content = fs.readFileSync(dest, 'utf8');
     expect(content).toMatch('guild_name = Test');
@@ -53,5 +54,6 @@ describe('utils', () => {
     expect(content).toMatch('db_output_filename = TopStats.db');
     expect(content).toMatch('db_update = true');
     expect(content).toMatch('fight_data_charts = true');
+    expect(content).toMatch('hide_columns = true');
   });
 });

--- a/index.html
+++ b/index.html
@@ -147,6 +147,9 @@
           <div class="config-row">
             <label><input type="checkbox" id="combiner-fight-charts" /> Generate Fight Charts</label>
           </div>
+          <div class="config-row">
+            <label><input type="checkbox" id="combiner-hide-columns" /> Hide Columns</label>
+          </div>
         </div>
       </div>
       <div id="settings-right">

--- a/index.html
+++ b/index.html
@@ -151,6 +151,12 @@
             <label><input type="checkbox" id="combiner-hide-columns" /> Hide Columns</label>
           </div>
         </div>
+        <div class="card" id="elite-insights-card">
+          <h3 class="card-title">Elite Insights</h3>
+          <div class="config-row">
+            <label><input type="checkbox" id="ei-anonymize" /> Anonymize Players</label>
+          </div>
+        </div>
       </div>
       <div id="settings-right">
         <div class="card" id="theme-card">

--- a/main.js
+++ b/main.js
@@ -556,7 +556,7 @@ ipcMain.handle('start-parse', async (event, data) => {
 
     const eiTemplate = path.join(__dirname, 'EliteInsightsConfigTemplate.conf');
     const eiConf = path.join(tempDir, 'EliteInsightConfig.conf');
-    await editEIConfig(eiTemplate, eiConf, tempDir, opts.dpsUserToken);
+    await editEIConfig(eiTemplate, eiConf, tempDir, opts.dpsUserToken, { anonymizePlayers: opts.anonymizePlayers });
     const combTemplate = path.join(__dirname, 'top_stats_config.ini');
     const combConf = path.join(tempDir, 'top_stats_config.ini');
     await editTopStatsConfig(combTemplate, combConf, opts);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topstatsaio",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/renderer.js
+++ b/renderer.js
@@ -42,6 +42,7 @@ const combinerApiKeyInput = document.getElementById('combiner-api-key');
 const combinerGlickoCheckbox = document.getElementById('combiner-glicko');
 const combinerFightChartsCheckbox = document.getElementById('combiner-fight-charts');
 const combinerHideColumnsCheckbox = document.getElementById('combiner-hide-columns');
+const eiAnonymizeCheckbox = document.getElementById('ei-anonymize');
 const descriptionInput = document.getElementById('description');
 const parseBtn = document.getElementById('parse-btn');
 const parseWindow = document.getElementById('parse-window');
@@ -141,6 +142,7 @@ combinerApiKeyInput.value = localStorage.getItem('combinerApiKey') || '';
 combinerGlickoCheckbox.checked = localStorage.getItem('combinerGlickoUpdate') === 'true';
 combinerFightChartsCheckbox.checked = localStorage.getItem('combinerFightCharts') === 'true';
 combinerHideColumnsCheckbox.checked = localStorage.getItem('combinerHideColumns') === 'true';
+eiAnonymizeCheckbox.checked = localStorage.getItem('eiAnonymizePlayers') === 'true';
 
 document.getElementById('minimize').addEventListener('click', () => window.electronAPI.minimize());
 document.getElementById('maximize').addEventListener('click', () => window.electronAPI.maximize());
@@ -370,6 +372,9 @@ combinerFightChartsCheckbox.addEventListener('change', () => {
 });
 combinerHideColumnsCheckbox.addEventListener('change', () => {
   localStorage.setItem('combinerHideColumns', combinerHideColumnsCheckbox.checked ? 'true' : 'false');
+});
+eiAnonymizeCheckbox.addEventListener('change', () => {
+  localStorage.setItem('eiAnonymizePlayers', eiAnonymizeCheckbox.checked ? 'true' : 'false');
 });
 parseBtn.addEventListener('click', startParse);
 parseCloseBtn.addEventListener('click', closeParseWindow);
@@ -1261,6 +1266,7 @@ async function startParse() {
     dbUpdate: localStorage.getItem('combinerGlickoUpdate') === 'true',
     fightCharts: localStorage.getItem('combinerFightCharts') === 'true',
     hideColumns: localStorage.getItem('combinerHideColumns') === 'true',
+    anonymizePlayers: localStorage.getItem('eiAnonymizePlayers') === 'true',
     description: descriptionInput.value.trim()
   };
   await window.electronAPI.startParse({ files, options });

--- a/renderer.js
+++ b/renderer.js
@@ -41,6 +41,7 @@ const combinerGuildLookupBtn = document.getElementById('combiner-guild-lookup');
 const combinerApiKeyInput = document.getElementById('combiner-api-key');
 const combinerGlickoCheckbox = document.getElementById('combiner-glicko');
 const combinerFightChartsCheckbox = document.getElementById('combiner-fight-charts');
+const combinerHideColumnsCheckbox = document.getElementById('combiner-hide-columns');
 const descriptionInput = document.getElementById('description');
 const parseBtn = document.getElementById('parse-btn');
 const parseWindow = document.getElementById('parse-window');
@@ -139,6 +140,7 @@ updateGuildLookupState();
 combinerApiKeyInput.value = localStorage.getItem('combinerApiKey') || '';
 combinerGlickoCheckbox.checked = localStorage.getItem('combinerGlickoUpdate') === 'true';
 combinerFightChartsCheckbox.checked = localStorage.getItem('combinerFightCharts') === 'true';
+combinerHideColumnsCheckbox.checked = localStorage.getItem('combinerHideColumns') === 'true';
 
 document.getElementById('minimize').addEventListener('click', () => window.electronAPI.minimize());
 document.getElementById('maximize').addEventListener('click', () => window.electronAPI.maximize());
@@ -365,6 +367,9 @@ combinerGlickoCheckbox.addEventListener('change', () => {
 });
 combinerFightChartsCheckbox.addEventListener('change', () => {
   localStorage.setItem('combinerFightCharts', combinerFightChartsCheckbox.checked ? 'true' : 'false');
+});
+combinerHideColumnsCheckbox.addEventListener('change', () => {
+  localStorage.setItem('combinerHideColumns', combinerHideColumnsCheckbox.checked ? 'true' : 'false');
 });
 parseBtn.addEventListener('click', startParse);
 parseCloseBtn.addEventListener('click', closeParseWindow);
@@ -1255,6 +1260,7 @@ async function startParse() {
     apiKey: localStorage.getItem('combinerApiKey') || '',
     dbUpdate: localStorage.getItem('combinerGlickoUpdate') === 'true',
     fightCharts: localStorage.getItem('combinerFightCharts') === 'true',
+    hideColumns: localStorage.getItem('combinerHideColumns') === 'true',
     description: descriptionInput.value.trim()
   };
   await window.electronAPI.startParse({ files, options });

--- a/top_stats_config.ini
+++ b/top_stats_config.ini
@@ -21,6 +21,8 @@ write_all_data_to_json = true
 db_update = false
 #Fight Data Charts toggle
 fight_data_charts = true
+#Hide Columns toggle
+hide_columns = false
 [Boon_Weights]
 #Boon weighting factor, higher weight = more important
 #Boon output * Weighting Factor = Boon Score

--- a/utils.js
+++ b/utils.js
@@ -38,6 +38,7 @@ async function editTopStatsConfig(template, dest, opts) {
     if (l.startsWith('db_path = ')) return `db_path = ${opts.dbPath || '.'}`;
     if (l.startsWith('db_update = ')) return `db_update = ${opts.dbUpdate ? 'true' : 'false'}`;
     if (l.startsWith('fight_data_charts = ')) return `fight_data_charts = ${opts.fightCharts ? 'true' : 'false'}`;
+    if (l.startsWith('hide_columns = ')) return `hide_columns = ${opts.hideColumns ? 'true' : 'false'}`;
     return l;
   }).join('\n');
   await fs.promises.writeFile(dest, replaced, 'utf8');

--- a/utils.js
+++ b/utils.js
@@ -18,11 +18,12 @@ function writeVersions(file, v) {
   fs.writeFileSync(file, JSON.stringify(v));
 }
 
-async function editEIConfig(template, dest, outDir, token) {
+async function editEIConfig(template, dest, outDir, token, opts = {}) {
   const lines = await fs.promises.readFile(template, 'utf8');
   const replaced = lines.split(/\r?\n/).map(l => {
     if (l.startsWith('OutLocation=')) return `OutLocation=${outDir}`;
     if (l.startsWith('DPSReportUserToken=')) return `DPSReportUserToken=${token || ''}`;
+    if (l.startsWith('Anonymous=')) return `Anonymous=${opts.anonymizePlayers ? 'True' : 'False'}`;
     return l;
   }).join('\n');
   await fs.promises.writeFile(dest, replaced, 'utf8');


### PR DESCRIPTION
## Summary
- add a Hide Columns checkbox to the GW2 EI Log Combiner settings panel
- persist the Hide Columns preference and feed it into the generated top_stats_config.ini file
- update the log combiner template and tests to cover the new hide_columns option

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2e4c191e8832f9035839f116e0136