### PR TITLE
ci: golden draft→publish release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+name: Build Release Artifacts
+
+# Golden release pattern: a tag push builds artifacts and writes notes into a
+# DRAFT release, then atomically flips it to published. GitHub's releases.atom
+# feed (which the AxiTools bot polls) never sees the release until it is
+# complete, so announcements are never empty or premature.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+  prepare-release:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          # If a non-draft release already exists, delete it so electron-builder
+          # can create and upload to a fresh draft.
+          existing=$(gh release view "$tag" --repo ${{ github.repository }} --json isDraft --jq '.isDraft' 2>/dev/null || echo "none")
+          if [ "$existing" = "false" ]; then
+            gh release delete "$tag" --repo ${{ github.repository }} --yes
+          fi
+          gh release create "$tag" --draft --title "$tag" --notes "" --repo ${{ github.repository }} 2>/dev/null || true
+
+  build:
+    needs: [prepare-release]
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            args: --linux AppImage
+          - os: windows-latest
+            args: --win nsis portable
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Native electron-builder publish uploads installers, latest.yml and
+      # blockmaps straight into the draft created above (package.json sets
+      # publish.releaseType=draft). flatpak is intentionally omitted in CI to
+      # match scripts/build-linux.js's AppImage-only fallback.
+      - name: Build and publish Electron distributables
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: npx electron-builder ${{ matrix.args }} --publish always
+
+  publish:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+
+          # Extract just this tag's section from RELEASE_NOTES.md.
+          # Sections start with a line like: "Version v3.4.4 - February 7, 2026".
+          notes=$(awk -v ver="$tag" '
+            /^Version v[0-9]/ { capture = ($2 == ver) ? 1 : 0; next }
+            capture { print }
+          ' RELEASE_NOTES.md)
+
+          # Fail loudly if there is no section for this tag, so a release is
+          # never published with empty or stale notes.
+          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            echo "::error::No RELEASE_NOTES.md section found for $tag. Add a 'Version $tag - <date>' entry and re-run." >&2
+            exit 1
+          fi
+
+          gh release edit "$tag" --repo ${{ github.repository }} --notes "$notes"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release edit "$tag" --repo ${{ github.repository }} --draft=false
+
+      # Optional immediate webhook ping. Leave the DISCORD_WEBHOOK_URL repo
+      # variable unset to rely solely on the AxiTools bot's RSS announcement.
+      - name: Post to Discord
+        if: ${{ vars.DISCORD_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ vars.DISCORD_WEBHOOK_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          release_url="https://github.com/${{ github.repository }}/releases/tag/${tag}"
+          notes=$(gh release view "$tag" --repo ${{ github.repository }} --json body --jq '.body' 2>/dev/null || echo "")
+
+          export TAG="$tag"
+          export RELEASE_URL="$release_url"
+          export NOTES="$notes"
+
+          payload=$(python3 -c "
+          import json, os
+
+          tag = os.environ['TAG']
+          release_url = os.environ['RELEASE_URL']
+          notes = os.environ.get('NOTES', '')
+
+          if len(notes) > 3800:
+              notes = notes[:3800] + '\n\n*... see full notes on GitHub*'
+
+          embed = {
+              'title': f'TopStatsAIO {tag}',
+              'url': release_url,
+              'description': notes or 'A new version of TopStatsAIO is available!',
+              'color': 0xF59E0B,
+              'thumbnail': {'url': 'https://raw.githubusercontent.com/darkharasho/TopStatsAIO/main/media/TopStatsAIO-Logo.png'},
+              'footer': {'text': 'TopStatsAIO Release'},
+          }
+
+          print(json.dumps({'embeds': [embed]}))
+          ")
+
+          curl -s -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Why

Our GitHub-releases RSS feed (polled by the AxiTools bot) gets tripped up when a release is published *before* its artifacts/changelog are attached — the bot announces an empty/partial release that never gets corrected. This brings TopStatsAIO in line with the proven axipulse/axibridge pattern so it only ever surfaces **complete** releases.

## What

Adds `.github/workflows/release.yml`, triggered on `v*` tag push:

1. **test** — `npm ci` + `npm test` (jest)
2. **prepare-release** — create an empty **draft** release for the tag (deletes a pre-existing non-draft first)
3. **build** (win + linux matrix) — `electron-builder --publish always` uploads installers, `latest.yml` and blockmaps straight into the draft (`package.json` already sets `publish.releaseType=draft`)
4. **publish** — extract this tag's section from `RELEASE_NOTES.md` (**fails loudly if missing**, so notes are never empty/stale), set it on the release, then atomically `gh release edit --draft=false`. Optional Discord webhook ping gated on a `DISCORD_WEBHOOK_URL` repo variable.

Because drafts don't appear in `releases.atom`, the release becomes visible to the feed only once it's fully built and noted.

## Decisions (per discussion)
- **Notes:** read from committed `RELEASE_NOTES.md` (deterministic, no secret) rather than regenerating via OpenAI in CI. Keep generating notes locally with your script before tagging.
- **Build:** native `electron-builder --publish` (auto `latest.yml` + blockmap for the auto-updater). Installer filenames become electron-builder defaults (e.g. `TopStatsAIO Setup 3.4.4.exe`) instead of the `scripts/build-win.js` renamed scheme.
- **Linux:** AppImage only in CI (matches `build-linux.js`'s no-flatpak fallback).

## Verify before merge
Cut a throwaway pre-release tag on this branch (e.g. `v0.0.0-test`) and confirm: a draft is created → artifacts upload → notes set → flips to published, and `releases.atom` shows it only after publish. Delete the test release/tag afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)